### PR TITLE
Add  HTTP Authentication and unhashed passwords

### DIFF
--- a/sugarcrm.py
+++ b/sugarcrm.py
@@ -22,12 +22,15 @@ import requests
 class Session:
 
     def __init__(self, url, username, password, app="Python", lang="en_us",
-                 verify=True):
+                 verify=True, httpauth=False, hashed=True):
         self.url = url
         self.username = username
+        self.password = password
         self.application = app
         self.language = lang
         self.verify = verify
+        self.httpauth = httpauth
+        self.hashed = hashed
         result = self.login(username, password)
         self.session_id = result['id']
 
@@ -38,7 +41,10 @@ class Session:
             'response_type': "JSON",
             'rest_data': json.dumps(params),
         }
-        r = requests.post(self.url, data=data, verify=self.verify)
+        if self.httpauth:
+            r = requests.post(self.url, data=data, verify=self.verify, auth=(self.username, self.password))
+        else:
+            r = requests.post(self.url, data=data, verify=self.verify)
         if r.status_code == 200:
             return json.loads(r.text.replace("&#039;", "'"))
         raise SugarError("SugarCRM API _request returned status code %d (%s)"
@@ -188,10 +194,15 @@ class Session:
 
     def login(self, username, password, app="Python", lang="en_us"):
         """Logs a user into the SugarCRM application."""
+
+        """Most but not all SugarCRM instances expect a hashed password."""
+        if self.hashed:
+            password = hashlib.md5(password.encode('utf8')).hexdigest()
+
         data = [
             {
                 'user_name': username,
-                'password': hashlib.md5(password.encode('utf8')).hexdigest()
+                'password': password
             },
             app,
             [{


### PR DESCRIPTION
Add HTTP Authentication option
Make hashed password optional because not all SugarCRM server expect a hashed password, rather than in plaintext